### PR TITLE
Expose reference_date as an Unhandled expression node

### DIFF
--- a/pyudunits2/_datetime.py
+++ b/pyudunits2/_datetime.py
@@ -27,7 +27,7 @@ class DateTime:
     time: Time = Time(0, 0)
     tz_offset: Time | str = "UTC"
     #: The original representation of the date time before any parsing.
-    raw_form: str | None = None
+    raw_content: str | None = None
 
     def __eq__(self, other: typing.Any) -> bool:
         if not isinstance(other, DateTime):

--- a/pyudunits2/_unit.py
+++ b/pyudunits2/_unit.py
@@ -311,6 +311,10 @@ def _unit_from_expression_and_identifiers(
             # Shifted and time => we have a date.
             # date_ref = DateUnit.parse(unit_expr.shift_from)
             date_ref = unit_expr.shift_from
+            if isinstance(date_ref, unit_graph.Number):
+                date_ref = unit_graph.Unhandled(date_ref.raw_content)
+            if not isinstance(date_ref, unit_graph.Unhandled):
+                raise ValueError(f"Unexpected parse type for date: {type(date_ref)}")
 
             return DateUnit(
                 unit=shifted_unit,
@@ -473,7 +477,7 @@ class DateUnit(UnitInterface):
         self,
         *,
         unit: Unit,
-        reference_date: DateTime,
+        reference_date: DateTime | unit_graph.Unhandled,
     ):
         assert unit.is_time_unit()
         self._unit = unit
@@ -488,7 +492,7 @@ class DateUnit(UnitInterface):
         return self._unit
 
     @property
-    def reference_date(self) -> DateTime:
+    def reference_date(self) -> DateTime | unit_graph.Unhandled:
         return self._reference_date
 
     def is_dimensionless(self) -> bool:

--- a/pyudunits2/tests/test_unit.py
+++ b/pyudunits2/tests/test_unit.py
@@ -86,6 +86,7 @@ def test_unit__init_with_date(expr: str, error_msg: str, common_id_refs):
     ["unit_expr", "expected_ref"],
     [
         ["s @ 2000", "2000"],
+        ["s @ 2000 +10 UTC", "2000 +10 UTC"],
         ["100s @ 2000", "2000"],
         ["years since 2000-01-01T00:00", "2000-01-01T00:00"],
         [

--- a/pyudunits2/tests/test_unit.py
+++ b/pyudunits2/tests/test_unit.py
@@ -101,6 +101,7 @@ def test_dateunit__reference_date(unit_expr: str, expected_ref, common_id_refs):
         definition, identifier_references=common_id_refs
     )
     assert isinstance(date_unit, DateUnit)
+    assert isinstance(date_unit.reference_date, graph.Unhandled)
     # TODO: get this assertion to be true.
     # assert isinstance(date_unit.reference_date, DateTime)
     assert str(date_unit.reference_date) == expected_ref


### PR DESCRIPTION
Expose reference_date as an Unhandled expression node. This will have the same interface as the DateTime once implemented, and means that the typing checks out. In the future, I expect we will always be able to expose a DateTeim, but for now this is good enough.