### PR TITLE
Expose a name property on a named unit (including BasisUnit)

### DIFF
--- a/pyudunits2/_unit.py
+++ b/pyudunits2/_unit.py
@@ -81,18 +81,6 @@ class Expression:
         return expand(sim, trig=False) == 0
 
 
-class UnitDefinition:
-    def __init__(
-        self, definition: Node, identifier_references: typing.Mapping[Identifier, Unit]
-    ):
-        self._definition = definition
-        self._expression_graph: Node
-        self._identifier_references: dict[Identifier, Prefix | Unit] = {}
-
-    def _to_sympy(self):
-        pass
-
-
 class Converter:
     def __init__(self, from_unit: Unit, to_unit: Unit):
         """
@@ -553,6 +541,10 @@ class NamedUnit(Unit):
             definition=definition, identifier_references=identifier_references
         )
         self._names = names
+
+    @property
+    def name(self) -> str:
+        return self._names.best_name()
 
 
 class BasisUnit(NamedUnit):

--- a/pyudunits2/_unit_reference.py
+++ b/pyudunits2/_unit_reference.py
@@ -42,3 +42,23 @@ class UnitReference:
     alias_names: tuple[Name, ...] = ()
     alias_symbols: tuple[str, ...] = ()
     description: str | None = ""
+
+    def __post_init__(self):
+        if (
+            self.name is None
+            and not self.symbols
+            and not self.alias_names
+            and not self.alias_symbols
+        ):
+            raise ValueError("name or symbol (or aliases) is required")
+
+    def best_name(self) -> str:
+        """Pick the most appropriate string which can be considered as a reasonable "name" approximation"""
+        if self.name:
+            return self.name.singular
+        if self.alias_names:
+            return self.alias_names[0].singular
+        if self.symbols:
+            return self.symbols[0]
+        if self.alias_symbols:
+            return self.alias_symbols[0]

--- a/pyudunits2/tests/test_unit.py
+++ b/pyudunits2/tests/test_unit.py
@@ -106,3 +106,11 @@ def test_dateunit__reference_date(unit_expr: str, expected_ref, common_id_refs):
     # TODO: get this assertion to be true.
     # assert isinstance(date_unit.reference_date, DateTime)
     assert str(date_unit.reference_date) == expected_ref
+
+
+def test__BasisUnit__name(common_id_refs):
+    year_unit = common_id_refs[graph.Identifier("years")]
+
+    assert str(year_unit) == "year"
+
+    assert year_unit.name == "year"


### PR DESCRIPTION
I'm not sure if we really need to do this just yet. The following already works:

```
from pyudunits2 import UnitSystem, BasisUnit, Unit

ut = UnitSystem.from_udunits2_xml()

m_unit = ut.unit('m')
meters_unit = ut.unit('meters')

assert str(m_unit) == 'm'
assert str(meters_unit) == 'meters'
assert m_unit == meters_unit

assert isinstance(meters_unit, Unit)
# Even though the dimensionality type gives us BasisUnits keys, we can compare against strings
assert meters_unit.dimensionality() == {'meter': 1}
assert m_unit.dimensionality() == {'meter': 1}

m_basis = list(m_unit.dimensionality().keys())[0]
print(type(m_basis))
print(str(m_basis))  # Gives us `meter` in both cases
```